### PR TITLE
Detect second-tier references copied by MSBUILD and enhance style for dark mode

### DIFF
--- a/Wax.Model/VisualStudio/Project.cs
+++ b/Wax.Model/VisualStudio/Project.cs
@@ -139,21 +139,28 @@
                 //Reference can be a project reference and not be built
                 if (File.Exists(reference.Path))
                 {
-                    //Load first-tier reference
-                    var assembly = Assembly.LoadFile(reference.Path);
-                    //Get its references
-                    var referenced = assembly.GetReferencedAssemblies();
-                    var directory = new FileInfo(reference.Path).Directory;
-                    foreach (var referred in referenced)
+                    try
                     {
-                        //If second-tier reference is not in project references
-                        if (!References.Any(r => r.Name == referred.Name))
+                        //Load first-tier reference
+                        var assembly = Assembly.LoadFile(reference.Path);
+                        //Get its references
+                        var referenced = assembly.GetReferencedAssemblies();
+                        var directory = new FileInfo(reference.Path).Directory;
+                        foreach (var referred in referenced)
                         {
-                            //Try to resolve it from first-tier reference folder like MSBuild does
-                            var existingDll = directory.GetFiles().FirstOrDefault(f => f.Name == string.Concat(referred.Name, ".dll"));
-                            if (existingDll != null)
-                                projectOutput.Add(new ProjectOutput(rootProject, existingDll.Name, BuildFileGroups.Built));
+                            //If second-tier reference is not in project references
+                            if (!References.Any(r => r.Name == referred.Name))
+                            {
+                                //Try to resolve it from first-tier reference folder like MSBuild does
+                                var existingDll = directory.GetFiles().FirstOrDefault(f => f.Name == string.Concat(referred.Name, ".dll"));
+                                if (existingDll != null)
+                                    projectOutput.Add(new ProjectOutput(rootProject, existingDll.Name, BuildFileGroups.Built));
+                            }
                         }
+                    }
+                    catch
+                    {
+                        //Reference cannot be loaded
                     }
                 }
             }

--- a/Wax.Model/VisualStudio/ProjectOutput.cs
+++ b/Wax.Model/VisualStudio/ProjectOutput.cs
@@ -21,7 +21,7 @@
             Contract.Requires(project != null);
             Contract.Requires(fullName != null);
 
-            if (buildFileGroup == BuildFileGroups.Built)
+            if (buildFileGroup == BuildFileGroups.Built || buildFileGroup == BuildFileGroups.Symbols)
             {
                 // Build output should be only a file name, without folder.
                 // => Workaround: In Web API projects (ASP.NET MVC) the build output is always "bin\<targetname>.dll" instead of just "<targetname>.dll",

--- a/Wax/MainView.xaml
+++ b/Wax/MainView.xaml
@@ -78,7 +78,7 @@
       </Setter>
     </Style>
   </UserControl.Resources>
-  <DockPanel>
+    <DockPanel Background="{x:Static SystemColors.ControlBrush}">
     <ToolBarTray DockPanel.Dock="Top" Margin="0">
       <ToolBar>
         <Button ToolTip="Refresh" Click="Refresh_Click">


### PR DESCRIPTION
Fix proposal for #15 and #17 

#17 is resolved by a quick fix, setting dockpanel's background color to ControlBrush, before implementing the TODO on setting VS Theme entirely on the main window.