### PR TITLE
Handling non-standard output

### DIFF
--- a/Wax.Model/Mapping/FileMapping.cs
+++ b/Wax.Model/Mapping/FileMapping.cs
@@ -37,7 +37,7 @@ namespace tomenglertde.Wax.Model.Mapping
         private readonly FilteredObservableCollection<UnmappedFile> _unmappedFiles;
         [NotNull]
         private readonly string _id;
-
+        private bool _isBuiltOrSymbol;
         private WixFileNode _mappedNode;
         private MappingState _mappingState;
 
@@ -51,6 +51,7 @@ namespace tomenglertde.Wax.Model.Mapping
             _allUnmappedProjectOutputs = allUnmappedProjectOutputs;
             _wixProject = wixProject;
             _allUnmappedFiles = allUnmappedFiles;
+            _isBuiltOrSymbol = projectOutput.RedirectToNonStandardOutput;
 
             _id = wixProject.GetFileId(SourceName);
 
@@ -120,6 +121,14 @@ namespace tomenglertde.Wax.Model.Mapping
                 var fileName = _projectOutput.FullName;
 
                 return Path.IsPathRooted(fileName) ? Path.GetFileName(fileName) : fileName;
+            }
+        }
+
+        public string DirectoryName
+        {
+            get
+            {
+                return (_isBuiltOrSymbol && Project.HasNonStandardOutput)?Project.NonStandardOutputPath : Path.GetDirectoryName(SourceName); ;
             }
         }
 

--- a/Wax.Model/Wix/WixProject.cs
+++ b/Wax.Model/Wix/WixProject.cs
@@ -251,7 +251,7 @@ namespace tomenglertde.Wax.Model.Wix
 
             var name = Path.GetFileName(filePath);
             var id = GetFileId(filePath);
-            var directoryName = Path.GetDirectoryName(filePath);
+            var directoryName = fileMapping.DirectoryName;
             var directoryId = GetDirectoryId(directoryName);
             var directory = DirectoryNodes.FirstOrDefault(node => node.Id.Equals(directoryId, StringComparison.OrdinalIgnoreCase));
             directoryId = directory != null ? directory.Id : "TODO: unknown directory " + directoryName;

--- a/Wax/MainViewModel.cs
+++ b/Wax/MainViewModel.cs
@@ -247,7 +247,7 @@ namespace tomenglertde.Wax
             unmappedFileNodes.AddRange(wixProject.FileNodes.Select(node => new UnmappedFile(node, unmappedFileNodes)));
 
             var projectOutputs = vsProjects
-                .SelectMany(project => project.GetProjectOutput(project, DeploySymbols))
+                .SelectMany(project => project.GetProjectOutput(project, DeploySymbols, true))
                 .OrderBy(item => item.IsReference ? 1 : 0)
                 .Distinct()
                 .ToArray();
@@ -265,7 +265,7 @@ namespace tomenglertde.Wax
             Contract.Requires(vsProjects != null);
             Contract.Requires(wixProject != null);
 
-            var directories = vsProjects.SelectMany(project => project.GetProjectOutput(project, DeploySymbols))
+            var directories = vsProjects.SelectMany(project => project.GetProjectOutput(project, DeploySymbols, false))
                 .Where(projectOutput => !projectOutput.IsReference)
                 .Select(projectOutput => Path.GetDirectoryName(projectOutput.FullName))
                 .Distinct(StringComparer.OrdinalIgnoreCase)


### PR DESCRIPTION
Fix for #21 

Detect non-standard file name on a built file (eg : filename is "bin\applicationdll")

Remember the non-standard output path

Generate the non-standard directory component (eg : bin_files)

Get the real source for the file (eg : TargetDir, and not TargetDir\bin)

Apply the non-standard output path in wxs placing every dlls and symbols into the non-standard directory component (bin_files)